### PR TITLE
Relaxes resque dependency constraints to ~>1.20 instead of ~>1.20.0

### DIFF
--- a/resque-brokered.gemspec
+++ b/resque-brokered.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "resque-brokered"
-  s.version     = "0.2"
+  s.version     = "0.2.1"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Andrew Harvey", "James Sadler"]
   s.email       = ["andrew@mootpointer.com", "freshtonic@gmail.com"]


### PR DESCRIPTION
Also added yajl-ruby as development dependency to allow specs to be run with bundle exec rake spec.
Bumped version in separate commit, ignore if you like.
