### PR TITLE
Allow new Resque 2.0 version which is not a complete rewrite

### DIFF
--- a/resque-brokered.gemspec
+++ b/resque-brokered.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_runtime_dependency 'resque', '~>1.20'
+  s.add_runtime_dependency 'resque', '>= 1.20', '<= 2.0'
   s.add_runtime_dependency 'redis'
 
   s.add_development_dependency 'rake'

--- a/resque-brokered.gemspec
+++ b/resque-brokered.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_runtime_dependency 'resque', '>= 1.20', '<= 2.0'
+  s.add_runtime_dependency 'resque', '>= 1.20', '< 2.1'
   s.add_runtime_dependency 'redis'
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
So it seems like Resque 2 has had a [bit of a dark release](https://github.com/resque/resque/tree/v2.0.0) and I thought I'd see how compatible this gem was given [earlier comments on the incompatibility](https://github.com/mootpointer/resque-brokered/pull/3#issuecomment-9510937)

Seems like it's now compatible, possibly because they turfed the entire rewrite of the Resque gem.

Observe!

A set of enqueued jobs on different queues
![enqueued jobs](https://user-images.githubusercontent.com/1305688/48459735-8eaaf980-e81f-11e8-8ccd-8235e58199e5.png)

A worker listening on a more specific, and then less specific queue, pulling jobs as expected
![processing jobs](https://user-images.githubusercontent.com/1305688/48459740-95397100-e81f-11e8-9c35-f7c78d31471d.png)

Empty queues!
![cleared jobs](https://user-images.githubusercontent.com/1305688/48459751-a1bdc980-e81f-11e8-97e9-e48caf2fe25d.png)

So this PR relaxes the Resque version requirement a little.

Thoughts? Concerns?
